### PR TITLE
Make PdfWriter binding conditional

### DIFF
--- a/config/pdf.php
+++ b/config/pdf.php
@@ -1,5 +1,7 @@
 <?php
 
+use Contoweb\Pdflib\Writers\PdflibPdfWriter;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -66,4 +68,14 @@ return [
         'disk' => 'local',
         'path' => '',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PDF writer
+    |--------------------------------------------------------------------------
+    |
+    | Define the writer class. It must implement the PdfWriter interface.
+    |
+    */
+    'writer' => PdflibPdfWriter::class,
 ];

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -68,14 +68,4 @@ return [
         'disk' => 'local',
         'path' => '',
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | PDF writer
-    |--------------------------------------------------------------------------
-    |
-    | Define the writer class. It must implement the PdfWriter interface.
-    |
-    */
-    'writer' => PdflibPdfWriter::class,
 ];

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -1,7 +1,5 @@
 <?php
 
-use Contoweb\Pdflib\Writers\PdflibPdfWriter;
-
 return [
     /*
     |--------------------------------------------------------------------------

--- a/config/pdf.php
+++ b/config/pdf.php
@@ -78,4 +78,14 @@ return [
     |
     */
     'writer' => PdflibPdfWriter::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | PDF creator
+    |--------------------------------------------------------------------------
+    |
+    | Define the creator of the PDF.
+    |
+    */
+    'creator' => env('PDFLIB_CREATOR', 'Laravel'),
 ];

--- a/src/PdflibServiceProvider.php
+++ b/src/PdflibServiceProvider.php
@@ -24,8 +24,10 @@ class PdflibServiceProvider extends ServiceProvider
             'pdf'
         );
 
-        $this->app->bindIf(PdfWriter::class, function () {
-            $writer = new PdflibPdfWriter(
+        $writerClass = config('pdf.writer') ?? PdflibPdfWriter::class;
+
+        $this->app->bindIf(PdfWriter::class, function () use ($writerClass) {
+            $writer = new $writerClass(
                 config('pdf.license'),
                 config('pdf.creator', 'Laravel')
             );

--- a/src/PdflibServiceProvider.php
+++ b/src/PdflibServiceProvider.php
@@ -24,10 +24,8 @@ class PdflibServiceProvider extends ServiceProvider
             'pdf'
         );
 
-        $writerClass = config('pdf.writer') ?? PdflibPdfWriter::class;
-
-        $this->app->bind(PdfWriter::class, function () use ($writerClass) {
-            $writer = new $writerClass(
+        $this->app->bindIf(PdfWriter::class, function () {
+            $writer = new PdflibPdfWriter(
                 config('pdf.license'),
                 config('pdf.creator', 'Laravel')
             );

--- a/src/PdflibServiceProvider.php
+++ b/src/PdflibServiceProvider.php
@@ -28,8 +28,8 @@ class PdflibServiceProvider extends ServiceProvider
 
         $this->app->bindIf(PdfWriter::class, function () use ($writerClass) {
             $writer = new $writerClass(
-                config('pdf.license'),
-                config('pdf.creator', 'Laravel')
+                $this->app['config']->get('pdf.license'),
+                $this->app['config']->get('pdf.creator')
             );
 
             if ($writer instanceof PdfWriter !== true) {


### PR DESCRIPTION
This pull request simplifies the PDF configuration and service registration by removing the ability to specify a custom PDF writer class in the configuration. The service provider now always uses the default `PdflibPdfWriter` class.

Further, it allows to define the Pdflib `creator` via the config.