### PR TITLE
Don't use host fonts

### DIFF
--- a/src/Writers/PdflibPdfWriter.php
+++ b/src/Writers/PdflibPdfWriter.php
@@ -117,6 +117,7 @@ class PdflibPdfWriter extends PDFlib implements PdfWriter
 
         $this->set_option('errorpolicy=return');
         $this->set_option('stringformat=utf8');
+        $this->set_option('usehostfonts=false');
     }
 
     /**


### PR DESCRIPTION
Disable host font usage in PDFlib to enforce explicit font source loading. Further, it solves PDFlib initialization problems on certain macOS versions.